### PR TITLE
Allow alternative XML format specs on the command line with the optional --xml or -x parameter

### DIFF
--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -13,7 +13,7 @@ that defines the CP2K input format specification.
 
 The --xml command line option takes precedence of this environment variable, however.
 """
-ENV_VAR_FOR_CP2K_INPUT_XML="FROMCP2K_XML_DEFINITION"
+ENV_VAR_FOR_CP2K_INPUT_XML = "FROMCP2K_XML_DEFINITION"
 
 
 @contextlib.contextmanager

--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -1,7 +1,6 @@
 import contextlib
 import pathlib
 import sys
-
 import click
 
 
@@ -86,6 +85,6 @@ def xml_option(func):
     return click.option(
         "--xml",
         "-x",
-        type=click.Path(exists=True, dir_okay=False),
+        type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
         help="Use alternative XML format specification file"
     )(func)

--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -80,3 +80,12 @@ def var_values_option(func):
         callback=click_validate_kv,
         help="preset the value for a CP2K preprocessor variable",
     )(func)
+
+
+def xml_option(func):
+    return click.option(
+        "--xml",
+        "-x",
+        type=click.Path(exists=True, dir_okay=False),
+        help="Use alternative XML format specification file"
+    )(func)

--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -4,6 +4,17 @@ import sys
 
 import click
 
+"""
+Environment variable that specifies the path to an alternative CP2K input XML definition file.
+
+When this environment variable is set, it overrides the default XML definition file
+location used by the application. The value should be a path to a valid XML file
+that defines the CP2K input format specification.
+
+The --xml command line option takes precedence of this environment variable, however.
+"""
+ENV_VAR_FOR_CP2K_INPUT_XML="FROMCP2K_XML_DEFINITION"
+
 
 @contextlib.contextmanager
 def smart_open(filename=None, mode="r"):

--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -85,7 +85,6 @@ def var_values_option(func):
 def xml_option(func):
     return click.option(
         "--xml",
-        "-x",
         type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
         help="Use alternative XML format specification file",
         default=None,

--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -1,6 +1,7 @@
 import contextlib
 import pathlib
 import sys
+
 import click
 
 
@@ -87,5 +88,5 @@ def xml_option(func):
         "-x",
         type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
         help="Use alternative XML format specification file",
-        default=None
+        default=None,
     )(func)

--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -86,5 +86,6 @@ def xml_option(func):
         "--xml",
         "-x",
         type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
-        help="Use alternative XML format specification file"
+        help="Use alternative XML format specification file",
+        default=None
     )(func)

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -58,11 +58,11 @@ def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
                 "Any key transformation function other than 'auto' is ignored when generating an aiida-cp2k run script template",
                 file=sys.stderr,
             )
-        cp2k_parser = CP2KInputParserAiiDA(base_dir=base_dir)
+        cp2k_parser = CP2KInputParserAiiDA(xmlspec=xml,base_dir=base_dir)
     elif canonical:
-        cp2k_parser = CP2KInputParser(base_dir=base_dir, key_trafo=trafo.value)
+        cp2k_parser = CP2KInputParser(xmlspec=xml,base_dir=base_dir, key_trafo=trafo.value)
     else:
-        cp2k_parser = CP2KInputParserSimplified(base_dir=base_dir, key_trafo=trafo.value)
+        cp2k_parser = CP2KInputParserSimplified(xmlspec=xml,base_dir=base_dir, key_trafo=trafo.value)
 
     tree = cp2k_parser.parse(fhandle, dict(var_values))
 

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -52,7 +52,8 @@ def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
     if not xml:
         xml = os.environ.get(ENV_VAR_FOR_CP2K_INPUT_XML)
 
-    print(f"    Using XML definition '{xml}'", file=sys.stderr)
+    if xml:
+        print(f"    Using XML definition '{xml}'", file=sys.stderr)
 
     if oformat == "aiida-cp2k-calc":
         if canonical:

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import sys
-from enum import Enum
+from enum import Enum, member
 from typing import Mapping, MutableSequence
 
 import click
@@ -23,9 +23,9 @@ def _key_trafo(string):
 
 class Trafos(Enum):
     # see https://stackoverflow.com/a/40486992 need to wrap functions in function objects
-    auto = functools.partial(_key_trafo)
-    lower = functools.partial(str.lower)
-    upper = functools.partial(str.upper)
+    auto = member(functools.partial(_key_trafo))
+    lower = member(functools.partial(str.lower))
+    upper = member(functools.partial(str.upper))
 
 
 @click.command()
@@ -45,8 +45,10 @@ class Trafos(Enum):
 )
 @var_values_option
 @xml_option
-def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values):
+def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
     """Convert CP2K input to JSON (default), YAML or an aiida-cp2k run script template"""
+
+    print(f"    Use XML definition '{xml}'")
 
     if oformat == "aiida-cp2k-calc":
         if canonical:

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -1,3 +1,4 @@
+import os
 import functools
 import json
 import sys
@@ -12,7 +13,7 @@ from cp2k_input_tools.parser import (
     CP2KInputParserSimplified,
 )
 
-from . import base_dir_option, canonical_option, fhandle_argument, var_values_option, xml_option
+from . import base_dir_option, canonical_option, fhandle_argument, var_values_option, xml_option, ENV_VAR_FOR_CP2K_INPUT_XML
 
 
 def _key_trafo(string):
@@ -47,6 +48,9 @@ class Trafos(Enum):
 @xml_option
 def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
     """Convert CP2K input to JSON (default), YAML or an aiida-cp2k run script template"""
+
+    if not xml:
+        xml = os.environ.get(ENV_VAR_FOR_CP2K_INPUT_XML)
 
     print(f"    Using XML definition '{xml}'", file=sys.stderr)
 

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -48,7 +48,7 @@ class Trafos(Enum):
 def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
     """Convert CP2K input to JSON (default), YAML or an aiida-cp2k run script template"""
 
-    print(f"    Use XML definition '{xml}'")
+    print(f"    Using XML definition '{xml}'", file=sys.stderr)
 
     if oformat == "aiida-cp2k-calc":
         if canonical:

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -12,7 +12,7 @@ from cp2k_input_tools.parser import (
     CP2KInputParserSimplified,
 )
 
-from . import base_dir_option, canonical_option, fhandle_argument, var_values_option
+from . import base_dir_option, canonical_option, fhandle_argument, var_values_option, xml_option
 
 
 def _key_trafo(string):
@@ -44,6 +44,7 @@ class Trafos(Enum):
     help="transformation applied to key and section names",
 )
 @var_values_option
+@xml_option
 def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values):
     """Convert CP2K input to JSON (default), YAML or an aiida-cp2k run script template"""
 

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -1,6 +1,6 @@
-import os
 import functools
 import json
+import os
 import sys
 from enum import Enum, member
 from typing import Mapping, MutableSequence
@@ -13,7 +13,7 @@ from cp2k_input_tools.parser import (
     CP2KInputParserSimplified,
 )
 
-from . import base_dir_option, canonical_option, fhandle_argument, var_values_option, xml_option, ENV_VAR_FOR_CP2K_INPUT_XML
+from . import ENV_VAR_FOR_CP2K_INPUT_XML, base_dir_option, canonical_option, fhandle_argument, var_values_option, xml_option
 
 
 def _key_trafo(string):

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -58,11 +58,11 @@ def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
                 "Any key transformation function other than 'auto' is ignored when generating an aiida-cp2k run script template",
                 file=sys.stderr,
             )
-        cp2k_parser = CP2KInputParserAiiDA(xmlspec=xml,base_dir=base_dir)
+        cp2k_parser = CP2KInputParserAiiDA(xmlspec=xml, base_dir=base_dir)
     elif canonical:
-        cp2k_parser = CP2KInputParser(xmlspec=xml,base_dir=base_dir, key_trafo=trafo.value)
+        cp2k_parser = CP2KInputParser(xmlspec=xml, base_dir=base_dir, key_trafo=trafo.value)
     else:
-        cp2k_parser = CP2KInputParserSimplified(xmlspec=xml,base_dir=base_dir, key_trafo=trafo.value)
+        cp2k_parser = CP2KInputParserSimplified(xmlspec=xml, base_dir=base_dir, key_trafo=trafo.value)
 
     tree = cp2k_parser.parse(fhandle, dict(var_values))
 

--- a/cp2k_input_tools/parser.py
+++ b/cp2k_input_tools/parser.py
@@ -67,7 +67,7 @@ class CP2KInputParser:
         :param key_trafo: A function object used for mangling key names, must treat input case-insensitive
         """
 
-        if None == xmlspec:
+        if xmlspec:
             xmlspec = DEFAULT_CP2K_INPUT_XML
 
         # schema:

--- a/cp2k_input_tools/parser.py
+++ b/cp2k_input_tools/parser.py
@@ -67,7 +67,7 @@ class CP2KInputParser:
         :param key_trafo: A function object used for mangling key names, must treat input case-insensitive
         """
 
-        if xmlspec:
+        if not xmlspec:
             xmlspec = DEFAULT_CP2K_INPUT_XML
 
         # schema:

--- a/cp2k_input_tools/parser.py
+++ b/cp2k_input_tools/parser.py
@@ -68,7 +68,7 @@ class CP2KInputParser:
         """
 
         if None == xmlspec:
-            xmlspec= DEFAULT_CP2K_INPUT_XML
+            xmlspec = DEFAULT_CP2K_INPUT_XML
 
         # schema:
         self._spec = ET.parse(xmlspec)

--- a/cp2k_input_tools/parser.py
+++ b/cp2k_input_tools/parser.py
@@ -58,7 +58,7 @@ class Section:
 
 
 class CP2KInputParser:
-    def __init__(self, xmlspec=DEFAULT_CP2K_INPUT_XML, base_dir=".", key_trafo=str.lower):
+    def __init__(self, xmlspec=None, base_dir=".", key_trafo=str.lower):
         """
         The CP2K input parser.
 
@@ -66,6 +66,9 @@ class CP2KInputParser:
         :param base_dir: The base directory to be used for resolving `@include` directives
         :param key_trafo: A function object used for mangling key names, must treat input case-insensitive
         """
+
+        if None == xmlspec:
+            xmlspec= DEFAULT_CP2K_INPUT_XML
 
         # schema:
         self._spec = ET.parse(xmlspec)


### PR DESCRIPTION
With this one can use the same cp2k-input-tools installation with different versions of CP2K. It doesn't change the default behavior using the built-in XML spec. It solves #34 and #43.