### PR TITLE
Alternative xml spec

### DIFF
--- a/cp2k_input_tools/cli/__init__.py
+++ b/cp2k_input_tools/cli/__init__.py
@@ -4,6 +4,17 @@ import sys
 
 import click
 
+"""
+Environment variable that specifies the path to an alternative CP2K input XML definition file.
+
+When this environment variable is set, it overrides the default XML definition file
+location used by the application. The value should be a path to a valid XML file
+that defines the CP2K input format specification.
+
+The --xml command line option takes precedence of this environment variable, however.
+"""
+ENV_VAR_FOR_CP2K_INPUT_XML = "FROMCP2K_XML_DEFINITION"
+
 
 @contextlib.contextmanager
 def smart_open(filename=None, mode="r"):
@@ -79,4 +90,13 @@ def var_values_option(func):
         type=click.UNPROCESSED,
         callback=click_validate_kv,
         help="preset the value for a CP2K preprocessor variable",
+    )(func)
+
+
+def xml_option(func):
+    return click.option(
+        "--xml",
+        type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
+        help="Use alternative XML format specification file",
+        default=None,
     )(func)

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -21,6 +21,7 @@ def _key_trafo(string):
         return string.upper()
     return string.lower()
 
+
 try:
     # Should be used in Python >= 3.11, needed in >= 3.14 to avoid a FutureWarning
     from enum import member

--- a/cp2k_input_tools/cli/fromcp2k.py
+++ b/cp2k_input_tools/cli/fromcp2k.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import os
 import sys
 from enum import Enum
 from typing import Mapping, MutableSequence
@@ -12,7 +13,7 @@ from cp2k_input_tools.parser import (
     CP2KInputParserSimplified,
 )
 
-from . import base_dir_option, canonical_option, fhandle_argument, var_values_option
+from . import ENV_VAR_FOR_CP2K_INPUT_XML, base_dir_option, canonical_option, fhandle_argument, var_values_option, xml_option
 
 
 def _key_trafo(string):
@@ -20,12 +21,20 @@ def _key_trafo(string):
         return string.upper()
     return string.lower()
 
+try:
+    # Should be used in Python >= 3.11, needed in >= 3.14 to avoid a FutureWarning
+    from enum import member
+except ImportError:
+    # Python 3.9 and earlier: Define 'member' as an identity function
+    def member(value):
+        return value
+
 
 class Trafos(Enum):
     # see https://stackoverflow.com/a/40486992 need to wrap functions in function objects
-    auto = functools.partial(_key_trafo)
-    lower = functools.partial(str.lower)
-    upper = functools.partial(str.upper)
+    auto = member(functools.partial(_key_trafo))
+    lower = member(functools.partial(str.lower))
+    upper = member(functools.partial(str.upper))
 
 
 @click.command()
@@ -44,8 +53,15 @@ class Trafos(Enum):
     help="transformation applied to key and section names",
 )
 @var_values_option
-def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values):
+@xml_option
+def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values, xml):
     """Convert CP2K input to JSON (default), YAML or an aiida-cp2k run script template"""
+
+    if not xml:
+        xml = os.environ.get(ENV_VAR_FOR_CP2K_INPUT_XML)
+
+    if xml:
+        print(f"    Using XML definition '{xml}'", file=sys.stderr)
 
     if oformat == "aiida-cp2k-calc":
         if canonical:
@@ -55,11 +71,11 @@ def fromcp2k(fhandle, oformat, canonical, base_dir, trafo, var_values):
                 "Any key transformation function other than 'auto' is ignored when generating an aiida-cp2k run script template",
                 file=sys.stderr,
             )
-        cp2k_parser = CP2KInputParserAiiDA(base_dir=base_dir)
+        cp2k_parser = CP2KInputParserAiiDA(xmlspec=xml, base_dir=base_dir)
     elif canonical:
-        cp2k_parser = CP2KInputParser(base_dir=base_dir, key_trafo=trafo.value)
+        cp2k_parser = CP2KInputParser(xmlspec=xml, base_dir=base_dir, key_trafo=trafo.value)
     else:
-        cp2k_parser = CP2KInputParserSimplified(base_dir=base_dir, key_trafo=trafo.value)
+        cp2k_parser = CP2KInputParserSimplified(xmlspec=xml, base_dir=base_dir, key_trafo=trafo.value)
 
     tree = cp2k_parser.parse(fhandle, dict(var_values))
 

--- a/cp2k_input_tools/parser.py
+++ b/cp2k_input_tools/parser.py
@@ -58,7 +58,7 @@ class Section:
 
 
 class CP2KInputParser:
-    def __init__(self, xmlspec=DEFAULT_CP2K_INPUT_XML, base_dir=".", key_trafo=str.lower):
+    def __init__(self, xmlspec=None, base_dir=".", key_trafo=str.lower):
         """
         The CP2K input parser.
 
@@ -66,6 +66,9 @@ class CP2KInputParser:
         :param base_dir: The base directory to be used for resolving `@include` directives
         :param key_trafo: A function object used for mangling key names, must treat input case-insensitive
         """
+
+        if not xmlspec:
+            xmlspec = DEFAULT_CP2K_INPUT_XML
 
         # schema:
         self._spec = ET.parse(xmlspec)


### PR DESCRIPTION
Allow to specify an alternative xml format definition file via a command line parameter (primary) or via an environment variable (secondary). If neither is given, use the default which is the old behavior.
